### PR TITLE
Make package version available (PEP8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ from setuptools import setup, find_packages, Extension
 from setuptools.command.test import test as TestCommand
 import sys
 import shlex
+from src.biopython import __version__
 
-
-release = "2.0a2"
+release = __version__
 
 
 if "sdist" in sys.argv:

--- a/src/biopython/__init__.py
+++ b/src/biopython/__init__.py
@@ -6,4 +6,7 @@
 from .file import *
 from .temp import *
 from .extensions import *
-from .copyable import *
+from .copyable import * 
+
+
+__version__ = "2.0a2"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,7 @@
+import biopython
+import pytest
+
+
+def test_version_number():
+    version = biopython.__version__
+    assert hasattr(biopython, "__version__")


### PR DESCRIPTION
This allows to check which version of biopython is installed as suggested by PEP8:

```python
> import biopython
> biopython.__version__
"2.0a2"
```