### PR TITLE
wrapper to load a structure file without instantiating a reader

### DIFF
--- a/src/biopython/structure/io/__init__.py
+++ b/src/biopython/structure/io/__init__.py
@@ -8,3 +8,4 @@ A subpackage for reading and writing structure related data.
 """
 
 from .trajfile import *
+from .structfile import *

--- a/src/biopython/structure/io/structfile.py
+++ b/src/biopython/structure/io/structfile.py
@@ -26,7 +26,7 @@ def read_structure_from_file(file_name, format=None):
     Examples
     --------
     Load a `\*.pdb` file:
-    
+        >>> from biopython.structure.io import read_structure_from_file
         >>> struct = read_structure_from_file('1l2y.pdb', format='pdb')
     """
     
@@ -34,7 +34,7 @@ def read_structure_from_file(file_name, format=None):
     if format is None:
         format = file_name.split('.')[-1]
         
-    # load correct reader
+    # load correct reader class
     class_path = "biopython.structure.io.{format}.{prefix}File".format(format=format.lower(), prefix=format.upper())
     module_name, class_name = class_path.rsplit(".", 1)
     MyClass = getattr(importlib.import_module(module_name), class_name)

--- a/src/biopython/structure/io/structfile.py
+++ b/src/biopython/structure/io/structfile.py
@@ -4,7 +4,7 @@
 
 import importlib
 
-def read_structure_from_file(file_name, format=None):
+def read_structure_from_file(file_name, format=None, extra_fields=[]):
     """
     This methods read a structure from a file.
     
@@ -16,6 +16,11 @@ def read_structure_from_file(file_name, format=None):
             The file format to be used. Can be any of the supported file
             formats as lowercase string. If no argument is given, the format
             will be guessed from the file extension.
+    extra_fields : list of str, optional
+            The strings in the list are optional annotation categories
+            that should be stored in the uoput array or stack.
+            There are 4 opional annotation identifiers:
+            'atom_id', 'b_factor', 'occupancy' and 'charge'.
         
     Returns
     -------
@@ -42,6 +47,6 @@ def read_structure_from_file(file_name, format=None):
     
     # read file and return struct
     reader.read(file_name)
-    stack = reader.get_structure()
+    stack = reader.get_structure(extra_fields)
     return stack
     

--- a/src/biopython/structure/io/structfile.py
+++ b/src/biopython/structure/io/structfile.py
@@ -1,0 +1,47 @@
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+import importlib
+
+def read_structure_from_file(file_name, format=None):
+    """
+    This methods read a structure from a file.
+    
+    Parameters
+    ----------
+    file_name : str
+            The name of the file to be read. Includes the file path.
+    format : str
+            The file format to be used. Can be any of the supported file
+            formats as lowercase string. If no argument is given, the format
+            will be guessed from the file extension.
+        
+    Returns
+    -------
+    array_stack : AtomArrayStack
+        A stack containing the annontation arrays from `template`
+        but the coordinates from the trajectory file.
+        
+    Examples
+    --------
+    Load a `\*.pdb` file:
+    
+        >>> struct = read_structure_from_file('1l2y.pdb', format='pdb')
+    """
+    
+    # guess file format
+    if format is None:
+        format = file_name.split('.')[-1]
+        
+    # load correct reader
+    class_path = "biopython.structure.io.{format}.{prefix}File".format(format=format.lower(), prefix=format.upper())
+    module_name, class_name = class_path.rsplit(".", 1)
+    MyClass = getattr(importlib.import_module(module_name), class_name)
+    reader = MyClass()
+    
+    # read file and return struct
+    reader.read(file_name)
+    stack = reader.get_structure()
+    return stack
+    

--- a/tests/structure/test_structfile.py
+++ b/tests/structure/test_structfile.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+from biopython.structure.io import read_structure_from_file
+import glob
+from os.path import join
+from .util import data_dir
+from biopython.structure.atoms import AtomArrayStack, AtomArray
+
+pdb_paths = glob.glob(join(data_dir, "*.pdb"))
+
+@pytest.mark.parametrize("path", glob.glob(join(data_dir, "*.pdb")))
+def test_assume_fileformat(path):
+    struct = read_structure_from_file(path)
+    assert isinstance(struct, AtomArrayStack) or isinstance(struct, AtomArray)
+    
+@pytest.mark.parametrize("path", glob.glob(join(data_dir, "*.pdb")))
+def test_load_pdb(path):
+    struct = read_structure_from_file(path, format='pdb')
+    assert isinstance(struct, AtomArrayStack) or isinstance(struct, AtomArray)


### PR DESCRIPTION
This adds a method that allows to read any supported file format without explicitly instantiating a reader class.

```python
> from biopython.structure.io import read_structure_from_file
> read_structure_from_file('1bl8.pdb', format='pdb') # format is optional
'AtomArray'
```